### PR TITLE
Add support for referencing Connection Error Sources in properties

### DIFF
--- a/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/linking/EMLinkingService.java
+++ b/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/linking/EMLinkingService.java
@@ -163,6 +163,8 @@ public class EMLinkingService extends PropertiesLinkingService {
 					if (searchResult != null) return Collections.singletonList(searchResult);
 					searchResult = EMV2Util.findOutgoingPropagationCondition(cxtElement, name);
 					if (searchResult != null) return Collections.singletonList(searchResult);
+					searchResult = EMV2Util.findConnectionErrorSource(cxtElement, name);
+					if (searchResult != null) return Collections.singletonList(searchResult);
 					if (cxtFGT != null){
 						// if previous element was feature group, look up next feature group in its type
 						// we do not want to return features as they should get resolved to an error propagation

--- a/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/util/EMV2Util.java
+++ b/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/util/EMV2Util.java
@@ -531,6 +531,21 @@ public class EMV2Util {
 		return null;
 	}
 
+	/**
+	 * Find ConnectionErrorSource with given classifier by looking through all connection error sources
+	 * @param el the element whose classifier we're using
+	 * @param name the name of the element to search for
+	 * @return the specified element, or null, if either the element's classifier is null or no
+	 * ConnectionErrorSource by the specified name was found
+	 */
+	public static ConnectionErrorSource findConnectionErrorSource(Element el, String name){
+		Classifier cl = el.getContainingClassifier();
+		if(cl != null){
+			Collection<ConnectionErrorSource> ceslist = getAllConnectionErrorSources(cl);
+			return (ConnectionErrorSource) AadlUtil.findNamedElementInList(ceslist, name);
+		}
+		return null;
+	}
 	
 
 	/**


### PR DESCRIPTION
This adds support for using `ConnectionErrorSource`s as values in reference properties.  It resolves #47.
