### PR TITLE
Add ability to reference error types in properties within EMV2 blocks

### DIFF
--- a/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/linking/EMLinkingService.java
+++ b/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/linking/EMLinkingService.java
@@ -193,6 +193,10 @@ public class EMLinkingService extends PropertiesLinkingService {
 						if (searchResult != null) {
 							return Collections.singletonList(searchResult);
 						}
+						searchResult = EMV2Util.findErrorType(cxtElement, name);
+						if (searchResult != null) {
+							return Collections.singletonList(searchResult);
+						}
 //					if (cxtElement instanceof Classifier) {
 						// look up subcomponent in classifier of previous subcomponent, or feature group
 						// we do not want to return features as they should get resolved to an error propagation

--- a/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/util/EMV2Util.java
+++ b/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/util/EMV2Util.java
@@ -589,6 +589,25 @@ public class EMV2Util {
 	}
 
 	/**
+	 * Find ErrorType with given name by looking through all error types 
+	 * referenced in all EMV2 subclauses of the supplied element's containing
+	 * classifier 
+	 * @param el the element whose classifier we're using
+	 * @param name the name of the Errortype to search for
+	 * @return the specified error type, or null, if either the element's classifier is null or no
+	 * ErrorType by the specified name was found
+	 */
+	public static ErrorType findErrorType(Element el, String name) {
+		Classifier cl = el.getContainingClassifier();
+		if (cl != null) {
+			for(ErrorModelSubclause currSubclause : getAllContainingClassifierEMV2Subclauses(cl))
+				for(ErrorModelLibrary currLibrary : currSubclause.getUseTypes())
+					return (ErrorType) AadlUtil.findNamedElementInList(currLibrary.getTypes(), name);
+		}
+		return null;
+	}
+	
+	/**
 	 * find the error flow whose incoming error propagation point is flowSource
 	 * @param eps List of error propagations
 	 * @param flowSource ErrorPropagation


### PR DESCRIPTION
## Summary

Error types cannot be referenced in via reference properties within EMV2 blocks right now, this pull request would fix that.

## Steps to Reproduce / Minimal Working Example

Using the following package:

```aadl
package ErrorTypeReferenceSystem
public
	with ErrorTypeReferencePropSet;
	
	system ErrorTypeReferenceSystem
	end ErrorTypeReferenceSystem;
	
	system implementation ErrorTypeReferenceSystem.imp
	annex EMV2 {**
		use types MyErrorTypeSet;
		properties
			ErrorTypeReferencePropSet::ErrorTypeReference => reference(MyErrorType);
		**};
	end ErrorTypeReferenceSystem.imp;

end ErrorTypeReferenceSystem;
```

And this EMV2 Error Type Library:

```aadl
package MyErrorTypeSet
public

annex EMV2
{**
	error types
		MyErrorType : type;
	end types;

**};

end MyErrorTypeSet;
```

And this property set:

```aadl
property set ErrorTypeReferencePropSet is
	ErrorTypeReference : reference ({emv2}**error type) applies to (all);
end ErrorTypeReferencePropSet;
```

### Desired Behavior

The successful compilation of the project should be allowed.

### Actual Behavior

The following errors are reported:

Description | Resource | Path | Location | Type
----------- | -------- | ---- | -------- | -----
Assigning reference value with incorrect Named Element class to property 'ErrorTypeReferencePropSet::ErrorTypeReference' of type 'ReferenceType' | ErrorTypeReference.aadl | /Sandbox/packages | line: 4 /Sandbox/packages/ErrorTypeReference.aadl | Xtext Check (fast)
Couldn't resolve reference to 'MyErrorType'. | ErrorTypeReference.aadl | /Sandbox/packages | line: 4 /Sandbox/packages/ErrorTypeReference.aadl| Xtext Check (fast)

## Solution

This pull request fixes the issue, and the desired behavior is produced from the example code.
