### PR TITLE
Add ability to reference error type sets in properties

### DIFF
--- a/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/linking/EMLinkingService.java
+++ b/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/linking/EMLinkingService.java
@@ -190,6 +190,10 @@ public class EMLinkingService extends PropertiesLinkingService {
 						if (searchResult != null) {
 							return Collections.singletonList(searchResult);
 						}
+						searchResult = EMV2Util.findErrorTypeSet(cxtElement, name);
+						if (searchResult != null) {
+							return Collections.singletonList(searchResult);
+						}
 //					if (cxtElement instanceof Classifier) {
 						// look up subcomponent in classifier of previous subcomponent, or feature group
 						// we do not want to return features as they should get resolved to an error propagation

--- a/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/util/EMV2Util.java
+++ b/org.osate.xtext.aadl2.errormodel/src/org/osate/xtext/aadl2/errormodel/util/EMV2Util.java
@@ -666,7 +666,28 @@ public class EMV2Util {
 		}
 		return null;
 	}
-
+	
+	/**
+	 * Find ErrorType set with given name by looking through all error types
+	 * referenced in all EMV2 subclauses of the supplied element's containing
+	 * classifier
+	 * @param el the element whose classifier we're using
+	 * @param name the name of the ErrorTypeSet to search for
+	 * @return the specified error type set, or null, if either the element's classifier is null or no
+	 * ErrorType by the specified name was found
+	 */
+	public static TypeSet findErrorTypeSet(Element el, String name) {
+		Classifier cl = getAssociatedClassifier(el);
+		if (cl != null) {
+			for (ErrorModelSubclause currSubclause : getAllContainingClassifierEMV2Subclauses(cl)) {
+				for (ErrorModelLibrary currLibrary : currSubclause.getUseTypes()) {
+					return (TypeSet) AadlUtil.findNamedElementInList(currLibrary.getTypesets(), name);
+				}
+			}
+		}
+		return null;
+	}
+	
 	/**
 	 * find the error flow whose incoming error propagation point is flowSource
 	 * @param eps List of error propagations


### PR DESCRIPTION
## Summary

Error type sets cannot be referenced in via reference properties within EMV2 blocks right now, this pull request would fix that.

## Steps to Reproduce / Minimal Working Example

Using the following package:

```aadl
package ErrorTypeSetReferenceSystem
public
    with ErrorTypeSetReferencePropSet;

    system ErrorTypeReferenceSystem
    end ErrorTypeReferenceSystem;

    system implementation ErrorTypeReferenceSystem.imp
    annex EMV2 {**
        use types MyErrorTypeSet;
        properties
            ErrorTypeSetReferencePropSet::ErrorTypeSetReference => reference(MyErrorTypeSet);
        **};
    end ErrorTypeReferenceSystem.imp;

end ErrorTypeSetReferenceSystem;
```

And this EMV2 Error Type Library:

```aadl
package MyErrorTypeSet
public

annex EMV2
{**
    error types
        MyFirstErrorType : type;
        MySecondErrorType : type;
        
        MyErrorTypeSet : type set {MyFirstErrorType, MySecondErrorType};
    end types;

**};

end MyErrorTypeSet;
```

And this property set:

```aadl
property set ErrorTypeSetReferencePropSet is
    ErrorTypeSetReference : reference ({emv2}**error type set) applies to (all);
end ErrorTypeSetReferencePropSet;
```

### Desired Behavior

The successful compilation of the project should be allowed.

### Actual Behavior

The following errors are reported:

Description | Resource | Path | Location | Type
----------- | -------- | ---- | -------- | -----
Couldn't resolve reference to 'MyErrorTypeSet'. | ErrorTypeSetReferenceSystem.aadl | /Sandbox | line: 4 /Sandbox/ErrorTypeSetReferenceSystem.aadl | Xtext Check (fast)


## Solution

This pull request fixes the issue, and the desired behavior is produced from the example code.
